### PR TITLE
Fix embedded web application

### DIFF
--- a/recipe/collect-node-licenses.mjs
+++ b/recipe/collect-node-licenses.mjs
@@ -1,0 +1,65 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+
+const [nodeModulesArg, outputArg] = process.argv.slice(2);
+if (!nodeModulesArg || !outputArg) {
+  throw new Error('usage: node collect-node-licenses.mjs <node_modules> <output.json>');
+}
+
+const packages = new Map();
+
+async function visitPackage(packagePath) {
+  const manifestPath = join(packagePath, 'package.json');
+  if (!existsSync(manifestPath)) return;
+
+  const resolvedPath = realpathSync(packagePath);
+  if (packages.has(resolvedPath)) return;
+
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  const license = typeof manifest.license === 'string' ? manifest.license : undefined;
+  if (!manifest.name || !manifest.version || !license) {
+    throw new Error(`incomplete license metadata in ${manifestPath}`);
+  }
+
+  const author = typeof manifest.author === 'string' ? manifest.author : manifest.author?.name;
+  packages.set(resolvedPath, {
+    name: manifest.name,
+    version: manifest.version,
+    path: resolvedPath,
+    license,
+    ...(author ? { author } : {}),
+    ...(manifest.homepage ? { homepage: manifest.homepage } : {}),
+    ...(manifest.description ? { description: manifest.description } : {}),
+  });
+
+  const nestedNodeModules = join(resolvedPath, 'node_modules');
+  if (existsSync(nestedNodeModules)) await visitNodeModules(nestedNodeModules);
+}
+
+async function visitNodeModules(nodeModulesPath) {
+  for (const entry of await readdir(nodeModulesPath, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+
+    const entryPath = join(nodeModulesPath, entry.name);
+    if (entry.name.startsWith('@')) {
+      for (const scopedEntry of await readdir(entryPath, { withFileTypes: true })) {
+        if (scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
+          await visitPackage(join(entryPath, scopedEntry.name));
+        }
+      }
+    } else if (entry.isDirectory() || entry.isSymbolicLink()) {
+      await visitPackage(entryPath);
+    }
+  }
+}
+
+await visitNodeModules(resolve(nodeModulesArg));
+
+const dependencies = [...packages.values()].sort((left, right) =>
+  `${left.name}@${left.version}:${left.path}`.localeCompare(`${right.name}@${right.version}:${right.path}`),
+);
+if (dependencies.length === 0) throw new Error(`no Node.js dependencies found under ${nodeModulesArg}`);
+
+await writeFile(resolve(outputArg), `${JSON.stringify({ 'msgvault-web': dependencies }, null, 2)}\n`);
+process.stdout.write(`collected license metadata for ${dependencies.length} Node.js packages\n`);

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,11 +12,14 @@ source:
 
 build:
   skip: win
-  number: 0
+  number: 1
   script:
-    - cd src/cmd/msgvault
+    - cd src
+    - make web-install web-embed
+    - cd cmd/msgvault
     - go-licenses save . --save_path ../../../library_licenses${{ ' --ignore github.com/mattn/go-localereader' if win else '' }}
     - go build -v -tags "fts5,duckdb_use_lib,libsqlite3" -o $PREFIX/bin/msgvault -ldflags="-s -w -X github.com/wesm/msgvault/cmd/msgvault/cmd.Version=v${PKG_VERSION}"
+    - node ../../scripts/check-web-assets.mjs --binary $PREFIX/bin/msgvault
     - if: unix
       then:
         - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/zsh/site-functions $PREFIX/share/fish/vendor_completions.d
@@ -30,7 +33,10 @@ requirements:
     - ${{ compiler("c") }}
     - ${{ compiler("cxx") }}
     - ${{ stdlib("c") }}
+    - bun >=1.3,<2
     - go-licenses
+    - make
+    - nodejs >=20.19,<25
   host:
     - libduckdb-devel
     - libsqlite

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,6 +16,8 @@ build:
   script:
     - cd src
     - make web-install web-embed
+    - node $RECIPE_DIR/collect-node-licenses.mjs web/node_modules frontend-license-input.json
+    - pnpm-licenses generate-disclaimer --json-input-file frontend-license-input.json --output-file frontend_licenses.txt
     - cd cmd/msgvault
     - go-licenses save . --save_path ../../../library_licenses${{ ' --ignore github.com/mattn/go-localereader' if win else '' }}
     - go build -v -tags "fts5,duckdb_use_lib,libsqlite3" -o $PREFIX/bin/msgvault -ldflags="-s -w -X github.com/wesm/msgvault/cmd/msgvault/cmd.Version=v${PKG_VERSION}"
@@ -37,6 +39,7 @@ requirements:
     - go-licenses
     - make
     - nodejs >=20.19,<25
+    - pnpm-licenses
   host:
     - libduckdb-devel
     - libsqlite
@@ -65,6 +68,7 @@ about:
   license_file:
     - src/LICENSE
     - library_licenses/
+    - src/frontend_licenses.txt
   documentation: https://pkg.go.dev/github.com/wesm/msgvault
   repository: https://github.com/wesm/msgvault
 


### PR DESCRIPTION
The v0.19.3 Conda package builds from GitHub's generated tag archive. That archive contains msgvault's browser compilation stub, but not the compiled Vite application. The installed executable can start its API, but every web interface route is missing.

Build the locked browser application before Go compilation and verify that the resulting executable contains the complete release asset graph. The build-number increase republishes v0.19.3 for users who already received the affected package.

The browser build also introduces a Node.js and TypeScript dependency graph into the shipped binary. Collect the exact packages installed from Bun's lockfile and include their license texts and notices alongside the existing Go dependency licenses.
